### PR TITLE
Update Project_Rimfactory_Revived.xml

### DIFF
--- a/1.6/Mods/Project RimFactory Revived/Patches/Project_Rimfactory_Revived.xml
+++ b/1.6/Mods/Project RimFactory Revived/Patches/Project_Rimfactory_Revived.xml
@@ -272,7 +272,7 @@
 	
 	
 	<!-- Mini Fishing Station -->
-	
+	<!--
 	<Operation Class="PatchOperationSequence">
 		<success>Normal</success>
 		<operations>			
@@ -289,5 +289,28 @@
 			
 		</operations>
 	</Operation>
+	-->
+	
+	<!-- PRF 1.6 update -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Odyssey</li>
+		</mods>
+		<nomatch Class="PatchOperationSequence">
+			<success>Normal</success>
+			<operations>			
+			
+				<li MayRequire="VanillaExpanded.VCEF" Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "PRF_MiniHelperFishing"]/modExtensions/li[@Class = "ProjectRimFactory.Drones.DefModExtension_DroneStation"]/workTypes</xpath>
+					<value>
+						<li>FSFRearming</li>
+						<li>FSFTransport</li>
+						<li>FSFCremating</li>
+						<li>FSFHauling</li>
+					</value>
+				</li>
 		
+			</operations>
+		</nomatch>
+	</Operation>
 </Patch>


### PR DESCRIPTION
Prevents Red errors on startup when loading PRF +VFE + Odyssey.
PRF made a conditional patch for this building to only show if Odyssey is not installed.
